### PR TITLE
Exclude master node from kubernetes node count

### DIFF
--- a/deploy.sh
+++ b/deploy.sh
@@ -22,7 +22,7 @@ KUBECTL="kubectl ${KUBECTL_PARAMS} --namespace=\"${NAMESPACE}\""
 eval "kubectl ${KUBECTL_PARAMS} create namespace \"${NAMESPACE}\""
 
 NODES=$(eval "${KUBECTL} get nodes -o go-template=\"{{range .items}}{{\\\$name := .metadata.name}}{{\\\$unschedulable := .spec.unschedulable}}{{range .status.conditions}}{{if eq .reason \\\"KubeletReady\\\"}}{{if eq .status \\\"True\\\"}}{{if not \\\$unschedulable}}{{\\\$name}}{{\\\"\\\\n\\\"}}{{end}}{{end}}{{end}}{{end}}{{end}}\"")
-ES_DATA_REPLICAS=$(echo "$NODES" | wc -l)
+ES_DATA_REPLICAS=$(($(echo "$NODES" | wc -l) - 1))
 
 if [ "$ES_DATA_REPLICAS" -lt 3 ]; then
   print_red "Minimum amount of Elasticsearch data nodes is 3 (in case when you have 1 replica shard), you have ${ES_DATA_REPLICAS} worker nodes"


### PR DESCRIPTION
We have a kubernetes setup where you can't put pods on the master node so we had to add more machines after deploying elk. By excluding the master node from the count, the deploy script will stop and send a warning in clusters with only 2 non-master nodes. I was wondering if this would be a useful addition in case it happens to others as well.